### PR TITLE
major content rewrite

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -100,7 +100,12 @@
                             </div>
                             <h3>Mark Wong</h3>
                             <p>
-                              Mark Wong is currently the president of the United States PostgreSQL Association.
+                              Mark Wong is currently the president and treasurer of the United States
+                              PostgreSQL Association while working as a consultant for 2ndQuadrant.
+                              His background was originally in database systems solutions and performance.
+                              He first introduced himself to the Postgres community in 2002 with open
+                              source benchmarking kits and results. Since then, he has continued to
+                              contribute to various aspects of the community.
                             </p>
                         </div>
                         <div class="box person">

--- a/template/index.html
+++ b/template/index.html
@@ -58,24 +58,21 @@
                         </header>
                         <div class="flex flex-2">
                             <article>
-                                <div class="image fit">
-                                    <img src="media/images/pic01.jpg" alt="Pic 01" />
-                                </div>
                                 <header>
                                     <h3>{{news.0.title}}</h3>
                                 </header>
-                                <p>{{news.0.summary|markdown|truncatewords:50}}</p>
+                                <p>{{news.0.summary|markdown|truncatewords:50}}</p><br><br>
                                 <footer>
                                     <a href="/news" class="button special">More</a>
                                 </footer>
                             </article>
                             <article>
                                 <header>
-                                    <h3>recent news posts</h3></br>
+                                    <h3>recent news posts</h3>
                                     <ul class="alt">
-				    	{%for newsitem in news %}
+                        				    	{%for newsitem in news %}
                                         <li>{{newsitem.title}}</li>
-					{%endfor%}
+                            					{%endfor%}
                                     </ul>
                                 </header>
                                 <footer>

--- a/template/pages/aboutus.html
+++ b/template/pages/aboutus.html
@@ -26,7 +26,7 @@
               <div class="4u 12u$(medium)">
                 <h3 class="top1">how can I contribute?</h3>
                 <p>If you are interested in supporting us, the best way is to <a href="/becomeamember">become a member</a> and
-                  actively contribute to our mission.<br><br>However, <a href="/donate">donations</a> are also an
+                  actively contribute to our mission.<br><br>However, <a href="/financialsupport">donations</a> are also an
                   excellent way to express appreciation for what we do.</p>
               </div>
               <div class="4u 12u$(medium)">

--- a/template/pages/associatedprojects.html
+++ b/template/pages/associatedprojects.html
@@ -1,0 +1,61 @@
+{%extends "base.html" %}
+{%load markup%}
+{%block title%}Associated Projects{%endblock%}
+{%block layoutblock%}
+
+<!-- Three -->
+  <section id="three" class="wrapper">
+    <div class="inner">
+      <header class="align-center">
+        <h2>associated projects</h2>
+      </header>
+      <div>
+        <h3 class="top2">who are our associated projects?</h3>
+        <p>
+          The United States PostgreSQL Associated has created an Associated Project framework to give legal and financial support
+          to projects that are aligned with PgUS's mission for their individual goals. If your project aligns with the PgUS mission
+          and you wish your project to be associated with PgUS, please review the
+          <a href="https://docs.google.com/document/d/12JyZqIUXKwmeqmlJziff5ISeKJgeP8ggzyjQB4VIp_A/pub">Associated Project guidelines</a>
+          and contact us at <a href="mailto:secretary@postgresql.us">secretary@postgresql.us</a>.
+        </p>
+        <a href="https://www.pgconf.us/">PGConf.US</a>
+        <ul>
+          <li><a href="http://blog.pgconf.us/p/team-governance.html">Governance</a></li>
+          <li>Financials</li>
+        </ul>
+        <p>Liaisons</p>
+        <ul>
+          <li>Jim Mlodgenski</li>
+          <li>Jonathan Katz</li>
+        </ul>
+        <p>Steering Committee</p>
+        <ul>
+          <li>Jim Mlodgenski</li>
+          <li>Jonathan Katz</li>
+          <li>Joshua Drake</li>
+        </ul>
+        <hr>
+        <a href="http://www.postgresopen.org/">PostgresOpen</a>
+        <ul>
+          <li>Governance</li>
+          <li>Financials</li>
+        </ul>
+        <p>Liaisons</p>
+        <ul>
+          <li>Stephen Frost</li>
+          <li>Joe Conway</li>
+        </ul>
+        <p>Steering Committee</p>
+        <ul>
+          <li>Stephen Frost</li>
+          <li>Joe Conway</li>
+          <li>Kris Pennella</li>
+          <li>Craig Kerstiens</li>
+          <li>Samantha Billington</li>
+          <li>Umur Cubukcu</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+{%endblock%}

--- a/template/pages/becomeamember.html
+++ b/template/pages/becomeamember.html
@@ -18,11 +18,11 @@
               </div>
               <div class="4u 12u$(medium)">
                 <h3 class="top3">benefits</h3>
-                <p>By becoming a member, you will be able to:<br></p>
+                <p>By becoming a member, you will be able to:</p>
                   <ul class="alt">
-                    <li>- influence and help how we support the growth of PostgreSQL.</li>
+                    <li>- influence the growth of PostgreSQL</li>
                     <li>- vote in board elections</li>
-                    <li>- support the United States PostgreSQL Community</li>
+                    <li>- support the US PostgreSQL community</li>
                   </ul>
               </div>
               <div class="4u$ 12u$(medium)">

--- a/template/pages/becomeamember.html
+++ b/template/pages/becomeamember.html
@@ -74,7 +74,7 @@
 								</div>
 
                 <p>
-                  If you still feel like contributing to our mission, but don't want any of the responsibility, we will <a href="/donate">happily take a donation</a>. Thank you for your participation and consideration of our mission!<br><br>
+                  If you still feel like contributing to our mission, but don't want any of the responsibility, we will <a href="/financialsupport">happily take a donation</a>. Thank you for your participation and consideration of our mission!<br><br>
                   Any further questions or concerns can be directed to our secretary using the email <a href="secretary@postgresql.us">secretary@postgresql.us</a>.
                 </p>
               </div>

--- a/template/pages/becomeamember.html
+++ b/template/pages/becomeamember.html
@@ -13,7 +13,9 @@
               <div class="4u 12u$(medium)">
                 <h3 class="top2">why join pgus?</h3>
                 <p>
-                  The United States PostgreSQL Association affectionately known as PgUS is a IRS 501(c)(3) public charity. Our purpose is to support the growth and education about The World's Most Advanced Open Source Database in the United States.
+                  The United States PostgreSQL Association affectionately known as PgUS is a IRS 501(c)(3) public charity.
+                  <br><br>Our purpose is to support the growth and education about The World's Most Advanced Open Source
+                  Database in the United States.
                 </p><br><br>
               </div>
               <div class="4u 12u$(medium)">

--- a/template/pages/becomeamember.html
+++ b/template/pages/becomeamember.html
@@ -77,7 +77,7 @@
 
                 <p>
                   If you still feel like contributing to our mission, but don't want any of the responsibility, we will <a href="/financialsupport">happily take a donation</a>. Thank you for your participation and consideration of our mission!<br><br>
-                  Any further questions or concerns can be directed to our secretary using the email <a href="secretary@postgresql.us">secretary@postgresql.us</a>.
+                  Any further questions or concerns can be directed to our secretary using the email <a href="mailto:secretary@postgresql.us">secretary@postgresql.us</a>.
                 </p>
               </div>
 

--- a/template/pages/contactus.html
+++ b/template/pages/contactus.html
@@ -53,7 +53,7 @@
                 <h3 class="top2">connect with us</h3>
                 <p>
                    Have a question or suggestion for the US PostgreSQL Association's Board of Directors? Contact us at <a href="mailto:secretary@postgresql.us">secretary@postgresql.us</a>!<br>
-                   Otherwise, please connect with us on social media.
+                   Otherwise, please connect with us on social media.<br><br>
                   <i class="fa fa-twitter-square" aria-hidden="true"></i> twitter: https://twitter.com/pgus<br>
                 </p>
               </div><!--

--- a/template/pages/corporate.html
+++ b/template/pages/corporate.html
@@ -28,14 +28,8 @@
                   projects that are aligned with PgUS's mission for their individual goals. If your project aligns with the PgUS mission and
                   you wish your project to be associated with PgUS, please review the
                   <a href="https://docs.google.com/document/d/12JyZqIUXKwmeqmlJziff5ISeKJgeP8ggzyjQB4VIp_A/pub">Associated Project guidelines</a>
-                  and contact us at <a href="mailto:secretary@postgresql.us">secretary@postgresql.us</a>.<br><br>
-                  <br><br>
-                  For more information on how we're involved with these associated projects, please visit <a href="/associatedprojects">our
-                    associated projects page.</a>
-                <ul class="alt">
-                  <li><a href="https://www.pgconf.us/">PGConf US</a></li>
-                  <li><a href="http://www.postgresopen.org/">PostgresOpen</a></li>
-                </ul>
+                  and contact us at <a href="mailto:secretary@postgresql.us">secretary@postgresql.us</a>. To look at our associated projects,
+                  please visit <a href="/associatedprojects">our associated projects page.</a>
                 </p>
               </div>
               <div class="4u 12u$(medium)">

--- a/template/pages/corporate.html
+++ b/template/pages/corporate.html
@@ -54,23 +54,23 @@
                 </thead>
                 <tbody>
                   <tr>
-                    <td><a href="../../media/files/PGUS_2015_IRS_Determination_Letter.pdf">PGUS_2015_IRS_Determination_Letter.pdf</a></td>
+                    <td><a href="../../media/files/financial/PGUS_2015_IRS_Determination_Letter.pdf">PGUS_2015_IRS_Determination_Letter.pdf</a></td>
                     <td>2 MB</td>
                   </tr>
                   <tr>
-                    <td><a href="../../media/files/Q1_2014">Q1 2014</a></td>
+                    <td><a href="../../media/files/financial/Q1_2014">Q1 2014</a></td>
                     <td>127 KB</td>
                   </tr>
                   <tr>
-                    <td><a href="../../media/files/Q4_2013">Q4 2013</a></td>
+                    <td><a href="../../media/files/financial/Q4_2013">Q4 2013</a></td>
                     <td>154 KB</td>
                   </tr>
                   <tr>
-                    <td><a href="../../media/files/Q3_2013">Q3_2013</a></td>
+                    <td><a href="../../media/files/financial/Q3_2013">Q3_2013</a></td>
                     <td>143 KB</td>
                   </tr>
                   <tr>
-                    <td><a href="../../media/files/Q1-Q2_2013">Q1-Q2_2013</a></td>
+                    <td><a href="../../media/files/financial/Q1-Q2_2013">Q1-Q2_2013</a></td>
                     <td>127 KB</td>
                   </tr>
                 </tbody>

--- a/template/pages/financialstatements.html
+++ b/template/pages/financialstatements.html
@@ -43,147 +43,147 @@
                   <td>127.21 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">Q4 2012</a></td>
+                  <td><a href="../../media/files/financial/Q4_2012.pdf">Q4 2012</a></td>
                   <td>95.51 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">Q3 2012</a></td>
+                  <td><a href="../../media/files/financial/Q3_2012.pdf">Q3 2012</a></td>
                   <td>83.54 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">Q2 2012</a></td>
+                  <td><a href="../../media/files/financial/Q2_2012.pdf">Q2 2012</a></td>
                   <td>83.74 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">Q1 2012</a></td>
+                  <td><a href="../../media/files/financial/Q1_2012.pdf">Q1 2012</a></td>
                   <td>86.84 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">December 2011</a></td>
+                  <td><a href="../../media/files/financial/Dec_2011.pdf">December 2011</a></td>
                   <td>125.4 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">November 2011</a></td>
+                  <td><a href="../../media/files/financial/Nov_2011.pdf">November 2011</a></td>
                   <td>123.79 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">October 2011</a></td>
+                  <td><a href="../../media/files/financial/Oct_2011.pdf">October 2011</a></td>
                   <td>124.98 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">September 2011</a></td>
+                  <td><a href="../../media/files/financial/Sep_2011.pdf">September 2011</a></td>
                   <td>123.82 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">August 2011</a></td>
+                  <td><a href="../../media/files/financial/Aug_2011.pdf">August 2011</a></td>
                   <td>124.43 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">July 2011</a></td>
+                  <td><a href="../../media/files/financial/Jul_2011.pdf">July 2011</a></td>
                   <td>161.18 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">June 2011</a></td>
+                  <td><a href="../../media/files/financial/Jun_2011.pdf">June 2011</a></td>
                   <td>124.18 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">May 2011</a></td>
+                  <td><a href="../../media/files/financial/May_2011.pdf">May 2011</a></td>
                   <td>120.61 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">April 2011</a></td>
+                  <td><a href="../../media/files/financial/Apr_2011.pdf">April 2011</a></td>
                   <td>113.5 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">March 2011</a></td>
+                  <td><a href="../../media/files/financial/Mar_2011.pdf">March 2011</a></td>
                   <td>111.25 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">February 2011</a></td>
+                  <td><a href="../../media/files/financial/Feb_2011.pdf">February 2011</a></td>
                   <td>111.66 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">January 2011</a></td>
+                  <td><a href="../../media/files/financial/Jan_2011.pdf">January 2011</a></td>
                   <td>108.19 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">December 2010</a></td>
+                  <td><a href="../../media/files/financial/Dec_2010.pdf">December 2010</a></td>
                   <td>117.97 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">November 2010</a></td>
+                  <td><a href="../../media/files/financial/Nov_2010.pdf">November 2010</a></td>
                   <td>108.92 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">August 2010</a></td>
+                  <td><a href="../../media/files/financial/Aug_2010.pdf">August 2010</a></td>
                   <td>106.47 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">May 2010</a></td>
-                  <td>102.63 KB</td>
-                </tr>
-                <tr>
-                  <td><a href="../../media/files/financial/">June 2010</a></td>
+                  <td><a href="../../media/files/financial/Jun_2010.pdf">June 2010</a></td>
                   <td>105.62 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">April 2010</a></td>
+                  <td><a href="../../media/files/financial/May_2010.pdf">May 2010</a></td>
+                  <td>102.63 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/Apr_2010.pdf">April 2010</a></td>
                   <td>103.31 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">March 2010	</a></td>
+                  <td><a href="../../media/files/financial/Mar_2010.pdf">March 2010	</a></td>
                   <td>104.05 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">February 2010</a></td>
+                  <td><a href="../../media/files/financial/Feb_2010.pdf">February 2010</a></td>
                   <td>100.66 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">January 2010</a></td>
+                  <td><a href="../../media/files/financial/Jan_2010.pdf">January 2010</a></td>
                   <td>95.9 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">December 2009</a></td>
+                  <td><a href="../../media/files/financial/Dec_2009.pdf">December 2009</a></td>
                   <td>145.4 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">November 2009</a></td>
+                  <td><a href="../../media/files/financial/Nov_2009.pdf">November 2009</a></td>
                   <td>108.92 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">October 2009</a></td>
+                  <td><a href="../../media/files/financial/Oct_2009.pdf">October 2009</a></td>
                   <td>316.66 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">September 2009</a></td>
+                  <td><a href="../../media/files/financial/Sep_2009.pdf">September 2009</a></td>
                   <td>124.19 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">August 2009</a></td>
+                  <td><a href="../../media/files/financial/Aug_2009.pdf">August 2009</a></td>
                   <td>320.04 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">July 2009</a></td>
+                  <td><a href="../../media/files/financial/Jul_2009.pdf">July 2009</a></td>
                   <td>123.57 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">June 2009</a></td>
+                  <td><a href="../../media/files/financial/Jun_2009.pdf">June 2009</a></td>
                   <td>298.52 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">May 2009</a></td>
+                  <td><a href="../../media/files/financial/May_2009.pdf">May 2009</a></td>
                   <td>311.63 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">April 2009</a></td>
+                  <td><a href="../../media/files/financial/Apr_2009.pdf">April 2009</a></td>
                   <td>202.58 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">January 09 through March 2009</a></td>
+                  <td><a href="../../media/files/financial/Jan-Mar_2009.pdf">January 09 through March 2009</a></td>
                   <td>197.06 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/">August 08 through December 2008</a></td>
+                  <td><a href="../../media/files/financial/Aug-Dec_2008.pdf">August 08 through December 2008</a></td>
                   <td>210.87 KB</td>
                 </tr>
               </tbody>

--- a/template/pages/financialstatements.html
+++ b/template/pages/financialstatements.html
@@ -43,147 +43,147 @@
                   <td>127.21 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">Q4 2012</a></td>
                   <td>95.51 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">Q3 2012</a></td>
                   <td>83.54 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">Q2 2012</a></td>
                   <td>83.74 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">Q1 2012</a></td>
                   <td>86.84 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">December 2011</a></td>
                   <td>125.4 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">November 2011</a></td>
                   <td>123.79 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">October 2011</a></td>
                   <td>124.98 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">September 2011</a></td>
                   <td>123.82 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">August 2011</a></td>
                   <td>124.43 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">July 2011</a></td>
                   <td>161.18 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">June 2011</a></td>
                   <td>124.18 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">May 2011</a></td>
                   <td>120.61 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">April 2011</a></td>
                   <td>113.5 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">March 2011</a></td>
                   <td>111.25 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">February 2011</a></td>
                   <td>111.66 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">January 2011</a></td>
                   <td>108.19 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">December 2010</a></td>
                   <td>117.97 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">November 2010</a></td>
                   <td>108.92 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">August 2010</a></td>
                   <td>106.47 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">May 2010</a></td>
                   <td>102.63 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">June 2010</a></td>
                   <td>105.62 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">April 2010</a></td>
                   <td>103.31 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">March 2010	</a></td>
                   <td>104.05 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">February 2010</a></td>
                   <td>100.66 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">January 2010</a></td>
                   <td>95.9 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">December 2009</a></td>
                   <td>145.4 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">November 2009</a></td>
                   <td>108.92 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">October 2009</a></td>
                   <td>316.66 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">September 2009</a></td>
                   <td>124.19 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">August 2009</a></td>
                   <td>320.04 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">July 2009</a></td>
                   <td>123.57 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">June 2009</a></td>
                   <td>298.52 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">May 2009</a></td>
                   <td>311.63 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">April 2009</a></td>
                   <td>202.58 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">January 09 through March 2009</a></td>
                   <td>197.06 KB</td>
                 </tr>
                 <tr>
-                  <td><a href="../../media/files/financial/"></a></td>
+                  <td><a href="../../media/files/financial/">August 08 through December 2008</a></td>
                   <td>210.87 KB</td>
                 </tr>
               </tbody>

--- a/template/pages/financialstatements.html
+++ b/template/pages/financialstatements.html
@@ -1,0 +1,52 @@
+{%extends "base.html" %}
+{%load markup%}
+{%block title%}Financial Statements{%endblock%}
+{%block layoutblock%}
+
+<!-- Three -->
+  <section id="three" class="wrapper">
+    <div class="inner">
+      <header class="align-center">
+        <h2>Financial Statements</h2>
+      </header>
+      <div>
+        <h3 class="top3">monthly financial reports</h3>
+        <p>On this page you will find the regular updates of the United States PostgreSQL Association
+          finances as prepared by our CPA, <a href="http://www.altensakai.com/">Alten & Sakai.</a></p>
+          <div class="table-wrapper">
+            <table class="alt">
+              <thead>
+                <tr>
+                  <th>Attachment</th>
+                  <th>Size</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><a href="../../media/files/financial/PGUS_2015_IRS_Determination_Letter.pdf">PGUS_2015_IRS_Determination_Letter.pdf</a></td>
+                  <td>2 MB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/Q1_2014">Q1 2014</a></td>
+                  <td>127 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/Q4_2013">Q4 2013</a></td>
+                  <td>154 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/Q3_2013">Q3_2013</a></td>
+                  <td>143 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/Q1-Q2_2013">Q1-Q2_2013</a></td>
+                  <td>127 KB</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+      </div>
+    </div>
+  </section>
+
+{%endblock%}

--- a/template/pages/financialstatements.html
+++ b/template/pages/financialstatements.html
@@ -24,23 +24,167 @@
               <tbody>
                 <tr>
                   <td><a href="../../media/files/financial/PGUS_2015_IRS_Determination_Letter.pdf">PGUS_2015_IRS_Determination_Letter.pdf</a></td>
-                  <td>2 MB</td>
+                  <td>2.19 MB</td>
                 </tr>
                 <tr>
                   <td><a href="../../media/files/financial/Q1_2014">Q1 2014</a></td>
-                  <td>127 KB</td>
+                  <td>127.41 KB</td>
                 </tr>
                 <tr>
                   <td><a href="../../media/files/financial/Q4_2013">Q4 2013</a></td>
-                  <td>154 KB</td>
+                  <td>154.99 KB</td>
                 </tr>
                 <tr>
                   <td><a href="../../media/files/financial/Q3_2013">Q3_2013</a></td>
-                  <td>143 KB</td>
+                  <td>143.6 KB</td>
                 </tr>
                 <tr>
                   <td><a href="../../media/files/financial/Q1-Q2_2013">Q1-Q2_2013</a></td>
-                  <td>127 KB</td>
+                  <td>127.21 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>95.51 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>83.54 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>83.74 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>86.84 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>125.4 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>123.79 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>124.98 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>123.82 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>124.43 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>161.18 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>124.18 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>120.61 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>113.5 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>111.25 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>111.66 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>108.19 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>117.97 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>108.92 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>106.47 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>102.63 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>105.62 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>103.31 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>104.05 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>100.66 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>95.9 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>145.4 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>108.92 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>316.66 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>124.19 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>320.04 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>123.57 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>298.52 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>311.63 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>202.58 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>197.06 KB</td>
+                </tr>
+                <tr>
+                  <td><a href="../../media/files/financial/"></a></td>
+                  <td>210.87 KB</td>
                 </tr>
               </tbody>
             </table>

--- a/template/pages/financialsupport.html
+++ b/template/pages/financialsupport.html
@@ -10,34 +10,6 @@
               <h2>financial support</h2>
             </header>
             <div>
-              <h3 class="top2">a helping hand</h3>
-              <p>
-                If you are a PostgreSQL associated user group, conference, or educational speaker needing financial assistance, we are happy to sponsor you.
-              </p>
-              <p>
-                Our assistance includes but is not limited to:
-              </p>
-              <ul>
-                <li>supporting the needs of PostgreSQL user groups</li>
-                <li>providing funds for educational speakers</li>
-                <li>assisting with trade show representation necessities</li>
-                <li>covering the costs for swag creation (t-shirts, flyers, educational materials, etc.)</li>
-              </ul>
-              <p>
-                Those being fiscally sponsored by PgUS maintain complete independence, free to receive financial sponsorship from other entities and to unassociate
-                themselves from PgUS at any time.
-              </p>
-              <p>
-                Those wishing to obtain our services are requested to fill out a formal application. Please email
-                <a href="mailto:secretary@postgresql.us">secretary@postgresql.us</a> to receive the application and further instructions. Please note the following:
-              </p>
-              <ul>
-                <li>Name & purpose</li>
-                <li>What services are needed</li>
-                <li>The liason for communicating with PgUS</li>
-              </ul>
-            </div>
-            <div>
               <h3 class="top1">help our mission</h3>
               <p>
                 The United States PostgreSQL Association provides financial support for a number of United States PostgreSQL activities - this is only made possible
@@ -60,34 +32,64 @@
                 </div>
               </p>
             </div>
-            <div>
-              <h3 class="top3">diversity scholarship</h3>
-              <p>
-                At the end of 2015, the United States PostgreSQL Association unanimously passed a resolution ear-marking $10,000 of funds for our Diversity Scholarship.
-                Since then, the Diversity Committee (comprised of Robert Treat, Kris Pennella, Gabrielle Roth and Lacey Williams Henschel) have been working to create
-                guidelines around what would be a beneficial program for the PostgreSQL community.
-              </p>
-              <p>
-                We are pleased to announce the application for the Diversity Scholarship is
-                <a href="https://docs.google.com/forms/d/e/1FAIpQLSe608VQuRZUSQQYnzZRa1ak1w8PSgQ_giCK_rfACaqDSuzYmA/viewform?c=0&w=1">open and available for submissions</a>.
-              </p>
-              <p>
-                You can apply to have some or all of your conference attendance costs (registration, hotel, airfare) covered. Just like submitting a talk, details count!
-                Your application should include specifics of how attending the event will benefit you, and how you plan to share the benefit with others in the community.
-              </p>
-                The decision making process will be ranked on 1 (low) to 5 (high) in the following areas:
+            <div class="row">
+              <div class="6u 12u$(medium)">
+                <h3 class="top2">a helping hand</h3>
+                <p>
+                  If you are a PostgreSQL associated user group, conference, or educational speaker needing financial assistance, we are happy to sponsor you.
+                </p>
+                <p>
+                  Our assistance includes but is not limited to:
+                </p>
                 <ul>
-                  <li>benefit to the applicant</li>
-                  <li>benefit to others (conference attendees, community members, applicant's coworkers, fellow students)</li>
-                  <li>(subjective) how serious do I feel the applicant is?</li>
-                  <li>(subjective) what is my overall feeling about the application?</li>
+                  <li>supporting the needs of PostgreSQL user groups</li>
+                  <li>providing funds for educational speakers</li>
+                  <li>assisting with trade show representation necessities</li>
+                  <li>covering the costs for swag creation (t-shirts, flyers, educational materials, etc.)</li>
                 </ul>
-              <p>
-                Each committee member will score applications in random order, without knowing other committee members' scores.
-              </p>
-              <p>
-                The Diversity Committee would like to thank our friends and members of the Django community for allowing us to review and borrow from their program.
-              </p>
+                <p>
+                  Those being fiscally sponsored by PgUS maintain complete independence, free to receive financial sponsorship from other entities and to unassociate
+                  themselves from PgUS at any time.
+                </p>
+                <p>
+                  Those wishing to obtain our services are requested to fill out a formal application. Please email
+                  <a href="mailto:secretary@postgresql.us">secretary@postgresql.us</a> to receive the application and further instructions. Please note the following:
+                </p>
+                <ul>
+                  <li>Name & purpose</li>
+                  <li>What services are needed</li>
+                  <li>The liason for communicating with PgUS</li>
+                </ul>
+              </div>
+              <div class="6u 12u$(medium)">
+                <h3 class="top3">diversity scholarship</h3>
+                <p>
+                  At the end of 2015, the United States PostgreSQL Association unanimously passed a resolution ear-marking $10,000 of funds for our Diversity Scholarship.
+                  Since then, the Diversity Committee (comprised of Robert Treat, Kris Pennella, Gabrielle Roth and Lacey Williams Henschel) have been working to create
+                  guidelines around what would be a beneficial program for the PostgreSQL community.
+                </p>
+                <p>
+                  We are pleased to announce the application for the Diversity Scholarship is
+                  <a href="https://docs.google.com/forms/d/e/1FAIpQLSe608VQuRZUSQQYnzZRa1ak1w8PSgQ_giCK_rfACaqDSuzYmA/viewform?c=0&w=1">open and available for submissions</a>.
+                </p>
+                <p>
+                  You can apply to have some or all of your conference attendance costs (registration, hotel, airfare) covered. Just like submitting a talk, details count!
+                  Your application should include specifics of how attending the event will benefit you, and how you plan to share the benefit with others in the community.
+                </p>
+                  The decision making process will be ranked on 1 (low) to 5 (high) in the following areas:
+                  <ul>
+                    <li>benefit to the applicant</li>
+                    <li>benefit to others (conference attendees, community members, applicant's coworkers, fellow students)</li>
+                    <li>(subjective) how serious do I feel the applicant is?</li>
+                    <li>(subjective) what is my overall feeling about the application?</li>
+                  </ul>
+                <p>
+                  Each committee member will score applications in random order, without knowing other committee members' scores.
+                </p>
+                <p>
+                  The Diversity Committee would like to thank our friends and members of the Django community for allowing us to review and borrow from their program.
+                </p>
+              </div>
             </div>
   				</div>
   			</section>


### PR DESCRIPTION
QUESTIONS: 

Where is the Your Membership pages located? The "before" becoming a member page is located under /membership/index, I realized, but where is the "after"? Need help creating a new account that isn't a member so I can see what the before page looks like, again.

Where are the list of blog and news articles kept?

Everything else is *done*, as far as I know. I'll take another pass through in the morning once this PR goes through, then I'll need you to comb through it as well, make sure nothing was missed.